### PR TITLE
timezone Gemの v1.0.0 以降への対応

### DIFF
--- a/embulk-output-influxdb.gemspec
+++ b/embulk-output-influxdb.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'tapp'
 
   spec.add_runtime_dependency 'influxdb', ['~> 0.2']
-  spec.add_runtime_dependency 'timezone'
+  spec.add_runtime_dependency 'timezone', ['~> 1.0']
 end

--- a/lib/embulk/output/influxdb.rb
+++ b/lib/embulk/output/influxdb.rb
@@ -189,7 +189,7 @@ module Embulk
       def convert_timezone(value)
         return value unless value.is_a?(Time)
 
-        timezone = Timezone::Zone.new(zone: @default_timezone)
+        timezone = Timezone::Zone.new(@default_timezone)
         timezone.time(value)
       end
 


### PR DESCRIPTION
timezone gem のコンストラクタは v1.0.0以降は Hashで指定できなくなっていましたので修正しました。

https://github.com/panthomakos/timezone/commit/e3a2cb6ca7b6dc3f7fa2105676b8e45a5461344b